### PR TITLE
Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "sirv public"
   },
   "devDependencies": {
+    "autoprefixer": "^10.0.1",
     "postcss": "^8.0.9",
     "postcss-load-config": "^2.1.0",
     "@rollup/plugin-commonjs": "^14.0.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('tailwindcss')],
+    plugins: [require('tailwindcss'), require('autoprefixer')],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,21 @@
 module.exports = {
   purge: {
-    mode: 'all',
-    content: ['./**/**/*.html', './**/**/*.svelte'],
+      mode: 'all',
+      content: ['./**/**/*.html', './**/**/*.svelte'],
 
-    options: {
-      whitelistPatterns: [/svelte-/],
-    },
+      options: {
+          whitelistPatterns: [/svelte-/],
+          defaultExtractor: (content) => [...content.matchAll(/(?:class:)*([\w\d-/:%.]+)/gm)].map(([_match, group, ..._rest]) => group),
+      },
   },
 
   theme: {
-    extend: {},
+      extend: {},
   },
   variants: {},
   plugins: [],
+  future: {
+      purgeLayersByDefault: true,
+      removeDeprecatedGapUtilities: true,
+  },
 };


### PR DESCRIPTION
- Added a new defaultextractor to the tailwind config to correctly retain tailwind styles used with Svelte's "class:" directive.
    * Found via [https://github.com/babichjacob/sapper-postcss-template](https://github.com/babichjacob/sapper-postcss-template)
- Added the autoprefixer postcss plugin to include vendor prefixes [as suggested by the tailwindcss devs](https://tailwindcss.com/docs/installation).
- Enabled the upcoming changes flags in the tailwind config [as suggested by the tailwindcss devs](https://tailwindcss.com/docs/upcoming-changes).